### PR TITLE
Add endpoint deletion

### DIFF
--- a/01-stable-diffusion-cats/02-finetune.ipynb
+++ b/01-stable-diffusion-cats/02-finetune.ipynb
@@ -1086,11 +1086,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "83fad3bc-6412-4f2e-b385-045bb37de39c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "execution_count": 56,
+   "id": "ef34cb19-93fe-476b-926c-8b1cbd1d44d9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Deleting endpoint configuration with name: js-ep-20230318162227\n",
+      "Deleting endpoint with name: js-ep-20230318162227\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Delete endpoint to save costs\n",
+    "predictor.delete_endpoint()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
It's recommended to add in the end of the notebook instructions to revert expensive actions that the user might incur (for example, keeping the inference endpoint)